### PR TITLE
Allows passing  all parameters to JSON.stringify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 module.exports = stringify
 
-function stringify (obj) {
+function stringify (obj, replacer, space) {
   decirc(obj, '', [], null)
-  return JSON.stringify(obj)
+  return JSON.stringify(obj, replacer, space)
 }
 function Circle (val, k, parent) {
   this.val = val


### PR DESCRIPTION
Now allows passing `replacer` and `space` parameters to JSON.stringify

ref: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify