### PR TITLE
Added replacer and space parameters

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-declare function stringify(data: any): string;
+declare function stringify(data: any, replacer: any, space: any): string;
 
 export = stringify;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 module.exports = stringify
 
-function stringify (obj) {
+function stringify (obj, replacer, space) {
   decirc(obj, '', [], null)
-  return JSON.stringify(obj)
+  return JSON.stringify(obj, replacer || null, space || 0)
 }
 function Circle (val, k, parent) {
   this.val = val

--- a/readme.md
+++ b/readme.md
@@ -15,10 +15,16 @@ o.o = o
 console.log(safeStringify(o))
 console.log(JSON.stringify(o)) //<-- throws
 ```
+If you need `replacer` and `space` parameters as you use them in *SON.stringify*, you can pass them as parameters.
+```js
+var safeStringify = require('fast-safe-stringify')
+safeStringify(obj, replacer, space)
+```
+By default *replacer* is *null* and *space* is *0* (zero), see the documentation [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
 
 ## Benchmarks
 
-The [json-stringify-safe](http://npm.im/json-stringify-safe) module supplies similar functionality with more info and flexibility. 
+The [json-stringify-safe](http://npm.im/json-stringify-safe) module supplies similar functionality with more info and flexibility.
 
 Although not JSON, the core `util.inspect` method can be used for similar purposes (e.g. logging) and also handles circular references.
 
@@ -34,10 +40,10 @@ jsonStringifySafeDeepBench*10000: 1062.449ms
 fastSafeStringifyDeepBench*10000: 177.926ms
 ```
 
-`fast-safe-stringify` is 2x faster for small objects, 
+`fast-safe-stringify` is 2x faster for small objects,
 and 6x faster for large objects than `json-stringify-safe`.
 
-`fast-safe-stringify` is 4x faster for small objects, 
+`fast-safe-stringify` is 4x faster for small objects,
 and 9x faster for large objects than `util.inspect`.
 
 
@@ -48,4 +54,3 @@ Sponsored by [nearForm](http://nearform.com)
 ## License
 
 MIT
-

--- a/test.js
+++ b/test.js
@@ -125,3 +125,20 @@ test('repeated non-circular references in arrays', function (assert) {
   assert.is(actual, expected)
   assert.end()
 })
+
+test('replacer and space default parameters', function (assert) {
+  var obj = { name: 'Tyrion Lannister', role: 'Hand of the Queen' }
+  var expected = s(obj, null, 0)
+  var actual = fss(obj)
+  assert.is(actual, expected)
+  assert.end()
+})
+
+test('replacer and space parameters', function (assert) {
+  var obj = { name: 'Qyburn', role: 'Hand of the Queen' }
+  var expected = s(obj, null, 2)
+  var actual = fss(obj, null, 2)
+  assert.is(actual, expected)
+  assert.end()
+})
+


### PR DESCRIPTION
Added *replacer* and *space* parameters to `JSON.stringify`, providing default parameters if nothing is given.
[Here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) the documentation.

```js
var safeStringify = require('fast-safe-stringify')
safeStringify(obj, replacer, space)
```