### PR TITLE
add files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.1",
   "description": "Safely and quickly serialize JavaScript objects",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
   "scripts": {
     "test": "standard && tap test.js"
   },


### PR DESCRIPTION
If you look [here](https://unpkg.com/fast-safe-stringify@1.1.1/) you'll notice that there are several files included with this package on the registry that don't need to be. This causes npm installs of this module to result in downloading more than necessary.

By adding this [`files`](https://docs.npmjs.com/files/package.json#files) array to `package.json` you can specifically list the files that are important for people to download for your module. By default, npm will also include `README` and `LICENSE` files as well.