### PR TITLE
Support pass through of JSON.stringify opts

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -27,7 +27,7 @@ var run = bench([
   function fastSafeStringifyBench (cb) {
     fastSafeStringify(obj)
     setImmediate(cb)
-  },  
+  },
   function inspectCircBench (cb) {
     inspect(circ)
     setImmediate(cb)
@@ -71,7 +71,7 @@ var run = bench([
   function fastSafeStringifyDeepTryFirstBench (cb) {
     tryStringify(deep) || fastSafeStringify(deep)
     setImmediate(cb)
-  },
+  }
 ], 10000)
 
 function tryStringify (obj) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@ module.exports = stringify
 
 function stringify (obj) {
   decirc(obj, '', [], null)
-  return JSON.stringify(obj)
+  var hasOpts = arguments.length > 1
+  return (hasOpts)
+    ? JSON.stringify.apply(JSON, arguments)
+    : JSON.stringify(obj)
 }
 function Circle (val, k, parent) {
   this.val = val

--- a/test.js
+++ b/test.js
@@ -153,3 +153,18 @@ test('double child circular reference', function (assert) {
   assert.deepEqual(fixture, cloned)
   assert.end()
 })
+
+test('allow JSON.stringify options', function (assert) {
+  var person = {name: 'Tyrion Lannister'}
+  var expected = '{\n\t"name": "Tywin Lannister"\n}'
+  var actual = fss(person, function (k, v) {
+    if (k === 'name') {
+      return 'Tywin Lannister'
+    } else {
+      return v
+    }
+  }, '\t')
+
+  assert.is(actual, expected)
+  assert.end()
+})


### PR DESCRIPTION
This is the one feature I missed from this more performant stringify lib. This includes the style fixes from previous PR.

cc @yunong