### PR TITLE
stringify is the default export.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 declare function stringify(data: any): string;
 
-export = stringify;
+export default stringify;


### PR DESCRIPTION
This corrects a bug when importing from TypeScript when using ES2015 modules.