### PR TITLE
Check if obj is null to avoid TypeError in pino

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = stringify
 stringify.default = stringify
 function stringify (obj) {
-  if (typeof obj === 'object' && typeof obj.toJSON !== 'function') {
+  if (obj !== null && typeof obj === 'object' && typeof obj.toJSON !== 'function') {
     decirc(obj, '', [], null)
   }
   return JSON.stringify(obj)


### PR DESCRIPTION
Currently I'm getting this error in pino since some obj passed by pino to fast-safe-stringify is null. To avoid this and to restore JSON.stringify(null) behavior an additional null check is introduced here.

```
  if (typeof obj === 'object' && typeof obj.toJSON !== 'function') {
                                           ^

TypeError: Cannot read property 'toJSON' of null
    at EventEmitter.stringify (C:\p\codellama.io\web\server\node_modules\fast-safe-stringify\index.js:4:44)
    at EventEmitter.asJson (C:\p\codellama.io\web\server\node_modules\pino\pino.js:137:22)
    at EventEmitter.pinoWrite (C:\p\codellama.io\web\server\node_modules\pino\pino.js:193:16)
    at EventEmitter.LOG (C:\p\codellama.io\web\server\node_modules\pino\lib\tools.js:117:10)
    at C:\p\codellama.io\web\server\lib\stats.js:8:12
    at C:\p\codellama.io\web\server\app\middleware.js:26:58
    at Array.<anonymous> (C:\p\codellama.io\web\server\node_modules\express-req-metrics\index.js:22:7)
    at listener (C:\p\codellama.io\web\server\node_modules\on-finished\index.js:169:15)
    at onFinish (C:\p\codellama.io\web\server\node_modules\on-finished\index.js:100:5)
    at callback (C:\p\codellama.io\web\server\node_modules\ee-first\index.js:55:10)
```