### PR TITLE
Force decirc when toJSON with Symbol.for('forceDecirc')

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function decirc (val, k, stack, parent) {
   } else if (val instanceof Circle) {
     val.count++
     return
-  } else if (typeof val.toJSON === 'function') {
+  } else if (typeof val.toJSON === 'function' && !val.toJSON.forceDecirc) {
     return
   } else if (parent) {
     if (~stack.indexOf(val)) {

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,23 @@ console.log(safeStringify(o))  // '{"a":1,"o":"[Circular]"}'
 console.log(JSON.stringify(o)) //<-- throws
 ```
 
+### toJSON support
+
+`fast-safe-stringify` would not attempt to detect circular dependencies
+on objects that have a `toJSON` function. If you need to do that, you
+will need to attach a `toJSON.forceDecirc = true` property, like
+so:
+
+```js
+var obj = {
+  toJSON: function () {
+    // something here..
+    return { something: 'else' }
+  }
+}
+obj.toJSON.forceDecirc = true
+```
+
 ## Benchmarks
 
 The [json-stringify-safe](http://npm.im/json-stringify-safe) module supplies similar functionality with more info and flexibility.


### PR DESCRIPTION
pino-noir has been broken since
https://github.com/davidmarkclements/fast-safe-stringify/pull/14.
This adds support for Symbol.for('forceDecirc') to actually force
the decirc support even when there is a toJSON function.