### PR TITLE
Top level force decirc

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = stringify
 stringify.default = stringify
 function stringify (obj) {
-  if (obj !== null && typeof obj === 'object' && typeof obj.toJSON !== 'function') {
+  if (obj !== null && typeof obj === 'object' && (typeof obj.toJSON !== 'function' || obj.toJSON.forceDecirc)) {
     decirc(obj, '', [], null)
   }
   return JSON.stringify(obj)

--- a/test.js
+++ b/test.js
@@ -236,3 +236,24 @@ test('nested child circular reference in toJSON', function (assert) {
   assert.is(actual, expected)
   assert.end()
 })
+
+test('forceDecirc works on top level object passed to stringify', function (assert) {
+  var circ = {}
+  circ.circ = circ
+  var o = {
+    circ: circ,
+    toJSON: function () {
+      return { circ: this.circ, y: 20 }
+    }
+  }
+  o.toJSON.forceDecirc = true
+  var expected = s({
+    circ: {
+      circ: '[Circular]'
+    },
+    y: 20
+  })
+  var actual = fss(o)
+  assert.is(actual, expected)
+  assert.end()
+})


### PR DESCRIPTION
As discussed briefly [here](https://github.com/davidmarkclements/fast-safe-stringify/pull/18#discussion_r148066117), if an object with `forceDecirc = true` is passed as the top-level object to `fss(obj)` it does not have any effect.

This PR adds a failing test for this behaviour and then provides the fix.