### PR TITLE
benchmarks: remove obsolete benchmarks

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -63,19 +63,7 @@ var run = bench([
   function fastSafeStringifyDeepCircBench (cb) {
     fastSafeStringify(deepCirc)
     setImmediate(cb)
-  },
-  function jsonStringifyDeepTryFirstBench (cb) {
-    tryStringify(deep) || jsonStringifySafe(deep)
-    setImmediate(cb)
-  },
-  function fastSafeStringifyDeepTryFirstBench (cb) {
-    tryStringify(deep) || fastSafeStringify(deep)
-    setImmediate(cb)
   }
 ], 10000)
-
-function tryStringify (obj) {
-  try { return JSON.stringify(obj) } catch (_) {}
-}
 
 run(run)


### PR DESCRIPTION
This code only tests JSON.stringify itself and that should be
obsolete.