### PR TITLE
feature: improve stable stringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v.2.1.0
+
+This release only changed the deterministic ("stable") stringify version
+
+Features
+
+- Improved performance in most cases
+- Manipulation of the input value is from now on possible
+
 ## v.2.0.0
 
 Features

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
+const stable = require('./stable')
+
 module.exports = stringify
 stringify.default = stringify
-stringify.stable = deterministicStringify
-stringify.stableStringify = deterministicStringify
+stringify.stable = stable
+stringify.stableStringify = stable
 
 const arr = []
 
@@ -36,66 +38,6 @@ function decirc (val, k, stack, parent) {
       for (i = 0; i < keys.length; i++) {
         var key = keys[i]
         decirc(val[key], key, stack, val)
-      }
-    }
-    stack.pop()
-  }
-}
-
-// Stable-stringify
-function compareFunction (a, b) {
-  if (a < b) {
-    return -1
-  }
-  if (a > b) {
-    return 1
-  }
-  return 0
-}
-
-function deterministicStringify (obj, replacer, spacer) {
-  const tmp = deterministicDecirc(obj, '', [], undefined) || obj
-  const res = JSON.stringify(tmp, replacer, spacer)
-  while (arr.length !== 0) {
-    var part = arr.pop()
-    part[0][part[1]] = part[2]
-  }
-  return res
-}
-
-function deterministicDecirc (val, k, stack, parent) {
-  var i
-  if (typeof val === 'object' && val !== null) {
-    for (i = 0; i < stack.length; i++) {
-      if (stack[i] === val) {
-        parent[k] = '[Circular]'
-        arr.push([parent, k, val])
-        return
-      }
-    }
-    if (typeof val.toJSON === 'function') {
-      return
-    }
-    stack.push(val)
-    // Optimize for Arrays. Big arrays could kill the performance otherwise!
-    if (Array.isArray(val)) {
-      for (i = 0; i < val.length; i++) {
-        deterministicDecirc(val[i], i, stack, val)
-      }
-    } else {
-      // Create a temporary object in the required way
-      const tmp = {}
-      const keys = Object.keys(val).sort(compareFunction)
-      for (i = 0; i < keys.length; i++) {
-        var key = keys[i]
-        deterministicDecirc(val[key], key, stack, val)
-        tmp[key] = val[key]
-      }
-      if (parent !== undefined) {
-        arr.push([parent, k, val])
-        parent[k] = tmp
-      } else {
-        return tmp
       }
     }
     stack.pop()

--- a/readme.md
+++ b/readme.md
@@ -45,12 +45,14 @@ Using the deterministic version also works the same:
 
 ```js
 const safeStringify = require('fast-safe-stringify')
+const stableSafeStringify = safeStringify.stableStringify
+
 const o = { b: 1, a: 0 }
 o.o = o
 
 console.log(safeStringify(o))
 // '{"b":1,"a":0,"o":"[Circular]"}'
-console.log(safeStringify.stableStringify(o))
+console.log(stableSafeStringify(o))
 // '{"a":0,"b":1,"o":"[Circular]"}'
 console.log(JSON.stringify(o))
 // TypeError: Converting circular structure to JSON
@@ -62,22 +64,12 @@ In general the behavior is identical to [JSON.stringify][]. The [`replacer`][]
 and [`space`][] options are also available.
 
 A few exceptions exist to [JSON.stringify][] while using [`toJSON`][] or
-[`replacer`][]:
+[`replacer`][] in combination with the regular safe stringify:
 
 ### Regular safe stringify
 
 - Manipulating a circular structure of the passed in value in a `toJSON` or the
   `replacer` is not possible! It is possible for any other value and property.
-
-- In case a circular structure is detected and the [`replacer`][] is used it
-  will receive the string `[Circular]` as the argument instead of the circular
-  object itself.
-
-### Deterministic ("stable") safe stringify
-
-- Manipulating the input object either in a [`toJSON`][] or the [`replacer`][]
-  function will not have any effect on the output. The output entirely relies on
-  the shape the input value had at the point passed to the stringify function!
 
 - In case a circular structure is detected and the [`replacer`][] is used it
   will receive the string `[Circular]` as the argument instead of the circular

--- a/stable.js
+++ b/stable.js
@@ -1,0 +1,491 @@
+'use strict'
+
+module.exports = stringify
+
+var gap = ''
+// eslint-disable-next-line
+const strEscapeSequencesRegExp = /[\x00-\x1f\x22\x5c]/
+// eslint-disable-next-line
+const strEscapeSequencesReplacer = /[\x00-\x1f\x22\x5c]/g
+
+// Escaped special characters. Use empty strings to fill up unused entries.
+const meta = [
+  '\\u0000', '\\u0001', '\\u0002', '\\u0003', '\\u0004',
+  '\\u0005', '\\u0006', '\\u0007', '\\b', '\\t',
+  '\\n', '\\u000b', '\\f', '\\r', '\\u000e',
+  '\\u000f', '\\u0010', '\\u0011', '\\u0012', '\\u0013',
+  '\\u0014', '\\u0015', '\\u0016', '\\u0017', '\\u0018',
+  '\\u0019', '\\u001a', '\\u001b', '\\u001c', '\\u001d',
+  '\\u001e', '\\u001f', '', '', '\\"',
+  '', '', '', '', '', '', '', '', '', '',
+  '', '', '', '', '', '', '', '', '', '',
+  '', '', '', '', '', '', '', '', '', '',
+  '', '', '', '', '', '', '', '', '', '',
+  '', '', '', '', '', '', '', '', '', '',
+  '', '', '', '', '', '', '', '\\\\'
+]
+
+const escapeFn = (str) => meta[str.charCodeAt(0)]
+
+// Escape control characters, double quotes and the backslash.
+function strEscape (str) {
+  // Some magic numbers that worked out fine while benchmarking with v8 6.0
+  if (str.length < 5000 && !strEscapeSequencesRegExp.test(str)) {
+    return `"${str}"`
+  }
+  if (str.length > 100) {
+    return `"${str.replace(strEscapeSequencesReplacer, escapeFn)}"`
+  }
+  var result = ''
+  var last = 0
+  for (var i = 0; i < str.length; i++) {
+    const point = str.charCodeAt(i)
+    if (point === 34 || point === 92 || point < 32) {
+      if (last === i) {
+        result += meta[point]
+      } else {
+        result += `${str.slice(last, i)}${meta[point]}`
+      }
+      last = i + 1
+    }
+  }
+  if (last === 0) {
+    result = str
+  } else if (last !== i) {
+    result += str.slice(last)
+  }
+  return `"${result}"`
+}
+
+// Full version: supports all options
+function stringifyFull (key, parent, stack, replacer, indent) {
+  var i, res, join
+  const mind = gap
+  var value = parent[key]
+
+  if (typeof value === 'object' && value !== null && typeof value.toJSON === 'function') {
+    value = value.toJSON(key)
+  }
+  if (typeof replacer === 'function') {
+    value = replacer.call(parent, key, value)
+  }
+
+  switch (typeof value) {
+    case 'object':
+      if (value === null) {
+        return 'null'
+      }
+      for (i = 0; i < stack.length; i++) {
+        if (stack[i] === value) {
+          return '"[Circular]"'
+        }
+      }
+      gap += indent
+
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          return '[]'
+        }
+        stack.push(value)
+        res = '['
+        if (gap === '') {
+          join = ','
+        } else {
+          res += '\n'
+          join = `,\n${gap}`
+        }
+        // Use null as a placeholder for non-JSON values.
+        for (i = 0; i < value.length - 1; i++) {
+          const tmp = stringifyFull(i, value, stack, replacer, indent)
+          res += tmp !== undefined ? tmp : 'null'
+          res += join
+        }
+        const tmp = stringifyFull(i, value, stack, replacer, indent)
+        res += tmp !== undefined ? tmp : 'null'
+        if (gap !== '') {
+          res += `\n${mind}`
+        }
+        res += ']'
+        stack.pop()
+        gap = mind
+        return res
+      }
+
+      // If the replacer is an array, use it to select the members to be stringified.
+      if (Array.isArray(replacer)) {
+        if (replacer.length === 0) {
+          return '{}'
+        }
+        stack.push(value)
+        res = '{'
+        if (gap === '') {
+          join = ','
+        } else {
+          res += '\n'
+          join = `,\n${gap}`
+        }
+        for (i = 0; i < replacer.length; i++) {
+          var last = false
+          if (typeof replacer[i] === 'string' || typeof replacer[i] === 'number') {
+            key = replacer[i]
+            const tmp = stringifyFull(key, value, stack, replacer, indent)
+            if (tmp !== undefined) {
+              if (last) {
+                res += join
+              }
+              res += `${strEscape(key)}${gap ? ': ' : ':'}${tmp}`
+              last = true
+            }
+          }
+        }
+      } else {
+        // Otherwise, iterate through all of the keys in the object.
+        const keys = Object.keys(value).sort(compareFunction)
+        if (keys.length === 0) {
+          return '{}'
+        }
+        stack.push(value)
+        res = '{'
+        if (gap === '') {
+          join = ','
+        } else {
+          res += '\n'
+          join = `,\n${gap}`
+        }
+        for (i = 0; i < keys.length - 1; i++) {
+          key = keys[i]
+          const tmp = stringifyFull(key, value, stack, replacer, indent)
+          if (tmp !== undefined) {
+            res += `${strEscape(key)}${gap ? ': ' : ':'}${tmp}`
+            res += join
+          }
+        }
+        key = keys[i]
+        const tmp = stringifyFull(key, value, stack, replacer, indent)
+        if (tmp !== undefined) {
+          res += `${strEscape(key)}${gap ? ': ' : ':'}${tmp}`
+        }
+      }
+      if (gap !== '') {
+        res += `\n${mind}`
+      }
+      res += '}'
+      stack.pop()
+      gap = mind
+      return res
+    case 'string':
+      return strEscape(value)
+    case 'number':
+      // JSON numbers must be finite. Encode non-finite numbers as null.
+      return isFinite(value) ? String(value) : 'null'
+    case 'boolean':
+      return value === true ? 'true' : 'false'
+  }
+}
+
+// Supports only the spacer option
+function stringifyIndent (key, value, stack, indent) {
+  var i, res, join
+  const mind = gap
+
+  switch (typeof value) {
+    case 'object':
+      if (value === null) {
+        return 'null'
+      }
+      if (typeof value.toJSON === 'function') {
+        value = value.toJSON(key)
+        // Prevent calling `toJSON` again.
+        if (typeof value !== 'object') {
+          return stringifyIndent(key, value, stack, indent)
+        }
+        if (value === null) {
+          return 'null'
+        }
+      }
+      for (i = 0; i < stack.length; i++) {
+        if (stack[i] === value) {
+          return '"[Circular]"'
+        }
+      }
+      gap += indent
+
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          return '[]'
+        }
+        stack.push(value)
+        res = '['
+        if (gap === '') {
+          join = ','
+        } else {
+          res += '\n'
+          join = `,\n${gap}`
+        }
+        // Use null as a placeholder for non-JSON values.
+        for (i = 0; i < value.length - 1; i++) {
+          const tmp = stringifyIndent(i, value[i], stack, indent)
+          res += tmp !== undefined ? tmp : 'null'
+          res += join
+        }
+        const tmp = stringifyIndent(i, value[i], stack, indent)
+        res += tmp !== undefined ? tmp : 'null'
+        if (gap !== '') {
+          res += `\n${mind}`
+        }
+        res += ']'
+        stack.pop()
+        gap = mind
+        return res
+      }
+
+      const keys = Object.keys(value).sort(compareFunction)
+      if (keys.length === 0) {
+        return '{}'
+      }
+      stack.push(value)
+      res = '{'
+      if (gap === '') {
+        join = ','
+      } else {
+        res += '\n'
+        join = `,\n${gap}`
+      }
+      for (i = 0; i < keys.length - 1; i++) {
+        key = keys[i]
+        const tmp = stringifyIndent(key, value[key], stack, indent)
+        if (tmp !== undefined) {
+          res += `${strEscape(key)}${gap ? ': ' : ':'}${tmp}`
+          res += join
+        }
+      }
+      key = keys[i]
+      const tmp = stringifyIndent(key, value[key], stack, indent)
+      if (tmp !== undefined) {
+        res += `${strEscape(key)}${gap ? ': ' : ':'}${tmp}`
+      }
+      if (gap !== '') {
+        res += `\n${mind}`
+      }
+      res += '}'
+      stack.pop()
+      gap = mind
+      return res
+    case 'string':
+      return strEscape(value)
+    case 'number':
+      // JSON numbers must be finite. Encode non-finite numbers as null.
+      return isFinite(value) ? String(value) : 'null'
+    case 'boolean':
+      return value === true ? 'true' : 'false'
+  }
+}
+
+// Supports only the replacer option
+function stringifyReplace (key, parent, stack, replacer) {
+  var i, res
+  var value = parent[key]
+  // If the value has a toJSON method, call it to obtain a replacement value.
+  if (typeof value === 'object' && value !== null && typeof value.toJSON === 'function') {
+    value = value.toJSON(key)
+  }
+  // If we were called with a replacer function, then call the replacer to
+  // obtain a replacement value.
+  if (typeof replacer === 'function') {
+    value = replacer.call(parent, key, value)
+  }
+
+  switch (typeof value) {
+    case 'object':
+      if (value === null) {
+        return 'null'
+      }
+      for (i = 0; i < stack.length; i++) {
+        if (stack[i] === value) {
+          return '"[Circular]"'
+        }
+      }
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          return '[]'
+        }
+        stack.push(value)
+        res = '['
+        // Use null as a placeholder for non-JSON values.
+        for (i = 0; i < value.length - 1; i++) {
+          const tmp = stringifySimple(i, value, stack, replacer)
+          res += tmp !== undefined ? tmp : 'null'
+          res += ','
+        }
+        const tmp = stringifySimple(i, value, stack, replacer)
+        res += tmp !== undefined ? tmp : 'null'
+        res += ']'
+        stack.pop()
+        return res
+      }
+
+      // If the replacer is an array, use it to select the members to be stringified.
+      if (Array.isArray(replacer)) {
+        if (replacer.length === 0) {
+          return '{}'
+        }
+        stack.push(value)
+        res = '{'
+        for (i = 0; i < replacer.length; i++) {
+          var last = false
+          if (typeof replacer[i] === 'string' || typeof replacer[i] === 'number') {
+            key = replacer[i]
+            const tmp = stringifyReplace(key, value, stack, replacer)
+            if (tmp !== undefined) {
+              if (last) {
+                res += ','
+              }
+              res += `${strEscape(key)}:${tmp}`
+              last = true
+            }
+          }
+        }
+      } else {
+        // Otherwise, iterate through all of the keys in the object.
+        const keys = Object.keys(value).sort(compareFunction)
+        if (keys.length === 0) {
+          return '{}'
+        }
+        stack.push(value)
+        res = '{'
+        for (i = 0; i < keys.length - 1; i++) {
+          key = keys[i]
+          const tmp = stringifyReplace(key, value, stack, replacer)
+          if (tmp !== undefined) {
+            res += `${strEscape(key)}:${tmp},`
+          }
+        }
+        key = keys[i]
+        const tmp = stringifyReplace(key, value, stack, replacer)
+        if (tmp !== undefined) {
+          res += `${strEscape(key)}:${tmp}`
+        }
+      }
+      res += '}'
+      stack.pop()
+      return res
+    case 'string':
+      return strEscape(value)
+    case 'number':
+      // JSON numbers must be finite. Encode non-finite numbers as null.
+      return isFinite(value) ? String(value) : 'null'
+    case 'boolean':
+      return value === true ? 'true' : 'false'
+  }
+}
+
+// Simple without any options
+function stringifySimple (key, value, stack) {
+  var i, res
+  switch (typeof value) {
+    case 'object':
+      if (value === null) {
+        return 'null'
+      }
+      if (typeof value.toJSON === 'function') {
+        value = value.toJSON(key)
+        // Prevent calling `toJSON` again
+        if (typeof value !== 'object') {
+          return stringifySimple(key, value, stack)
+        }
+        if (value === null) {
+          return 'null'
+        }
+      }
+      for (i = 0; i < stack.length; i++) {
+        if (stack[i] === value) {
+          return '"[Circular]"'
+        }
+      }
+
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          return '[]'
+        }
+        stack.push(value)
+        res = '['
+        // Use null as a placeholder for non-JSON values.
+        for (i = 0; i < value.length - 1; i++) {
+          const tmp = stringifySimple(i, value[i], stack)
+          res += tmp !== undefined ? tmp : 'null'
+          res += ','
+        }
+        const tmp = stringifySimple(i, value[i], stack)
+        res += tmp !== undefined ? tmp : 'null'
+        res += ']'
+        stack.pop()
+        return res
+      }
+
+      const keys = Object.keys(value).sort(compareFunction)
+      if (keys.length === 0) {
+        return '{}'
+      }
+      stack.push(value)
+      res = '{'
+      for (i = 0; i < keys.length - 1; i++) {
+        key = keys[i]
+        const tmp = stringifySimple(key, value[key], stack)
+        if (tmp !== undefined) {
+          res += `${strEscape(key)}:${tmp},`
+        }
+      }
+      key = keys[i]
+      const tmp = stringifySimple(key, value[key], stack)
+      if (tmp !== undefined) {
+        res += `${strEscape(key)}:${tmp}`
+      }
+      res += '}'
+      stack.pop()
+      return res
+    case 'string':
+      return strEscape(value)
+    case 'number':
+      // JSON numbers must be finite. Encode non-finite numbers as null.
+      return isFinite(value) ? String(value) : 'null'
+    case 'boolean':
+      return value === true ? 'true' : 'false'
+  }
+}
+
+function compareFunction (a, b) {
+  if (a < b) {
+    return -1
+  }
+  if (a > b) {
+    return 1
+  }
+  return 0
+}
+
+function stringify (value, replacer, spacer) {
+  var i
+  var indent = ''
+  gap = ''
+
+  if (arguments.length > 1) {
+    // If the spacer parameter is a number, make an indent string containing that
+    // many spaces.
+    if (typeof spacer === 'number') {
+      for (i = 0; i < spacer; i += 1) {
+        indent += ' '
+      }
+    // If the spacer parameter is a string, it will be used as the indent string.
+    } else if (typeof spacer === 'string') {
+      indent = spacer
+    }
+    if (indent !== '') {
+      if (replacer) {
+        return stringifyFull('', { '': value }, [], replacer, indent)
+      }
+      return stringifyIndent('', value, [], indent)
+    }
+    return stringifyReplace('', { '': value }, [], replacer)
+  }
+  return stringifySimple('', value, [])
+}

--- a/test-stable.js
+++ b/test-stable.js
@@ -227,17 +227,11 @@ test('nested child circular reference in toJSON', function (assert) {
       baz: '[Redacted]'
     },
     bar: {
-      // TODO: This is a known limitation of the current implementation.
-      // The ideal result would be:
-      //
-      // b: 2,
-      // baz: {
-      //   circle: '[Circular]',
-      //   some: 'data'
-      // }
-      //
-      b: '[Redacted]',
-      baz: '[Redacted]'
+      b: 2,
+      baz: {
+        circle: '[Circular]',
+        some: 'data'
+      }
     }
   })
   const actual = fss(o)


### PR DESCRIPTION
This is a performance improvement in many cases. For big / deep
objects it will be a minor performance penalty in the case no
options are used.
If options are used (i.e. replacer or spacer) it will always be
faster.

The implementation is side effect free, so it now works 1-to-1 as
JSON.stringify.

For performance reasons this is a lot of duplicated code... I do not see a much nicer implementation right now that could do the same though :/.

No options:
```
old:   simple object x 916,356 ops/sec ±0.95% (95 runs sampled)
old:   circular      x 367,928 ops/sec ±1.00% (94 runs sampled)
old:   deep          x 16,704 ops/sec ±1.01% (91 runs sampled)
old:   deep circular x 16,234 ops/sec ±1.44% (91 runs sampled)

fast-safe-stringify:   simple object x 1,389,123 ops/sec ±0.63% (96 runs sampled)
fast-safe-stringify:   circular      x 477,570 ops/sec ±1.05% (90 runs sampled)
fast-safe-stringify:   deep          x 15,363 ops/sec ±1.00% (91 runs sampled)
fast-safe-stringify:   deep circular x 15,175 ops/sec ±0.90% (95 runs sampled)
```

Spacer
```
old:   simple object x 966,154 ops/sec ±1.09% (91 runs sampled)
old:   circular      x 295,570 ops/sec ±0.55% (95 runs sampled)
old:   deep          x 13,203 ops/sec ±0.81% (95 runs sampled)
old:   deep circular x 12,707 ops/sec ±1.10% (94 runs sampled)

fast-safe-stringify:   simple object x 1,214,236 ops/sec ±1.08% (93 runs sampled)
fast-safe-stringify:   circular      x 428,453 ops/sec ±0.82% (88 runs sampled)
fast-safe-stringify:   deep          x 14,071 ops/sec ±0.78% (92 runs sampled)
fast-safe-stringify:   deep circular x 13,856 ops/sec ±0.98% (92 runs sampled)
```

Replacer
```
old:   simple object x 939,815 ops/sec ±2.50% (90 runs sampled)
old:   circular      x 210,840 ops/sec ±0.72% (91 runs sampled)
old:   deep          x 12,708 ops/sec ±0.98% (91 runs sampled)
old:   deep circular x 12,358 ops/sec ±0.81% (90 runs sampled)

fast-safe-stringify:   simple object x 1,166,188 ops/sec ±0.71% (92 runs sampled)
fast-safe-stringify:   circular      x 445,552 ops/sec ±1.10% (92 runs sampled)
fast-safe-stringify:   deep          x 14,685 ops/sec ±1.04% (95 runs sampled)
fast-safe-stringify:   deep circular x 14,540 ops/sec ±0.89% (94 runs sampled)
```

Both
```
old:   simple object x 957,466 ops/sec ±1.20% (89 runs sampled)
old:   circular      x 194,075 ops/sec ±0.66% (93 runs sampled)
old:   deep          x 10,923 ops/sec ±0.86% (89 runs sampled)
old:   deep circular x 10,514 ops/sec ±1.26% (92 runs sampled)

fast-safe-stringify:   simple object x 1,117,194 ops/sec ±0.94% (92 runs sampled)
fast-safe-stringify:   circular      x 407,977 ops/sec ±1.06% (90 runs sampled)
fast-safe-stringify:   deep          x 13,700 ops/sec ±1.26% (93 runs sampled)
fast-safe-stringify:   deep circular x 13,570 ops/sec ±1.18% (95 runs sampled)
```