### PR TITLE
Fix typescript typing from add namespace for stable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 declare function stringify(data: any): string;
 
 declare namespace stringify {
-  export declare function stable(data: any): string;
-  export declare function stableStringify(data: any): string;
+  export function stable(data: any): string;
+  export function stableStringify(data: any): string;
 }
 
 export default stringify;


### PR DESCRIPTION
The new typing has a compile error this corrects it. Thanks!