### PR TITLE
Updating stringify signature to match JSON.stringify signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare function stringify(data: any): string;
+declare function stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string;
 
 declare namespace stringify {
   export function stable(data: any): string;


### PR DESCRIPTION
The current call signature for `stringify` in `index.d.ts` does not allow for a *replacer* or *space* argument even though they are supported.  Trying to use these arguments produces Typescript compilation errors.
```javascript
declare function stringify(data: any): string;
```
I updated the signature to match that of `JSON.stringify` as this is the proper signature and allows for the supported arguments.
```javascript
declare function stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string;
```
Here is a workaround for anyone else experiencing this issue.
```typescript
(stringify as any)(value, replacerFn, space)
```