### PR TITLE
Fix #44 Add support for circular getter references

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -37,60 +37,60 @@ for (let i = 0; i < 10; i++) {
   }
 }
 
-suite.add('util.inspect:          simple object            ', function () {
+suite.add('util.inspect:          simple object              ', function () {
   inspect(obj, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          circular                 ', function () {
+suite.add('util.inspect:          circular                   ', function () {
   inspect(circ, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          circular getters         ', function () {
+suite.add('util.inspect:          circular getters           ', function () {
   inspect(circGetters, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          deep                     ', function () {
+suite.add('util.inspect:          deep                       ', function () {
   inspect(deep, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          deep circular            ', function () {
+suite.add('util.inspect:          deep circular              ', function () {
   inspect(deepCirc, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          10+ deep circular getters', function () {
+suite.add('util.inspect:          large deep circular getters', function () {
   inspect(deepCircGetters, { showHidden: false, depth: null })
 })
 
-suite.add('\njson-stringify-safe:   simple object            ', function () {
+suite.add('\njson-stringify-safe:   simple object              ', function () {
   jsonStringifySafe(obj)
 })
-suite.add('json-stringify-safe:   circular                 ', function () {
+suite.add('json-stringify-safe:   circular                   ', function () {
   jsonStringifySafe(circ)
 })
-suite.add('json-stringify-safe:   circular getters         ', function () {
+suite.add('json-stringify-safe:   circular getters           ', function () {
   jsonStringifySafe(circGetters)
 })
-suite.add('json-stringify-safe:   deep                     ', function () {
+suite.add('json-stringify-safe:   deep                       ', function () {
   jsonStringifySafe(deep)
 })
-suite.add('json-stringify-safe:   deep circular            ', function () {
+suite.add('json-stringify-safe:   deep circular              ', function () {
   jsonStringifySafe(deepCirc)
 })
-suite.add('json-stringify-safe:   10+ deep circular getters', function () {
+suite.add('json-stringify-safe:   large deep circular getters', function () {
   jsonStringifySafe(deepCircGetters)
 })
 
-suite.add('\nfast-safe-stringify:   simple object            ', function () {
+suite.add('\nfast-safe-stringify:   simple object              ', function () {
   fastSafeStringify(obj)
 })
-suite.add('fast-safe-stringify:   circular                 ', function () {
+suite.add('fast-safe-stringify:   circular                   ', function () {
   fastSafeStringify(circ)
 })
-suite.add('fast-safe-stringify:   circular getters         ', function () {
+suite.add('fast-safe-stringify:   circular getters           ', function () {
   fastSafeStringify(circGetters)
 })
-suite.add('fast-safe-stringify:   deep                     ', function () {
+suite.add('fast-safe-stringify:   deep                       ', function () {
   fastSafeStringify(deep)
 })
-suite.add('fast-safe-stringify:   deep circular            ', function () {
+suite.add('fast-safe-stringify:   deep circular              ', function () {
   fastSafeStringify(deepCirc)
 })
-suite.add('fast-safe-stringify:   10+ deep circular getters', function () {
+suite.add('fast-safe-stringify:   large deep circular getters', function () {
   fastSafeStringify(deepCircGetters)
 })
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -37,6 +37,28 @@ for (let i = 0; i < 10; i++) {
   }
 }
 
+const deepCircNonCongifurableGetters = JSON.parse(JSON.stringify(deep))
+Object.defineProperty(deepCircNonCongifurableGetters.deep.deep.deep, 'circ', {
+  get: () => deepCircNonCongifurableGetters,
+  enumerable: true,
+  configurable: false
+})
+Object.defineProperty(deepCircNonCongifurableGetters.deep.deep, 'circ', {
+  get: () => deepCircNonCongifurableGetters,
+  enumerable: true,
+  configurable: false
+})
+Object.defineProperty(deepCircNonCongifurableGetters.deep, 'circ', {
+  get: () => deepCircNonCongifurableGetters,
+  enumerable: true,
+  configurable: false
+})
+Object.defineProperty(deepCircNonCongifurableGetters, 'array', {
+  get: () => array,
+  enumerable: true,
+  configurable: false
+})
+
 suite.add('util.inspect:          simple object              ', function () {
   inspect(obj, { showHidden: false, depth: null })
 })
@@ -54,6 +76,9 @@ suite.add('util.inspect:          deep circular              ', function () {
 })
 suite.add('util.inspect:          large deep circular getters', function () {
   inspect(deepCircGetters, { showHidden: false, depth: null })
+})
+suite.add('util.inspect:          deepCircNonCongifurableGetters', function () {
+  inspect(deepCircNonCongifurableGetters, { showHidden: false, depth: null })
 })
 
 suite.add('\njson-stringify-safe:   simple object              ', function () {
@@ -74,6 +99,9 @@ suite.add('json-stringify-safe:   deep circular              ', function () {
 suite.add('json-stringify-safe:   large deep circular getters', function () {
   jsonStringifySafe(deepCircGetters)
 })
+suite.add('json-stringify-safe:   deepCircNonCongifurableGetters', function () {
+  jsonStringifySafe(deepCircNonCongifurableGetters)
+})
 
 suite.add('\nfast-safe-stringify:   simple object              ', function () {
   fastSafeStringify(obj)
@@ -92,6 +120,9 @@ suite.add('fast-safe-stringify:   deep circular              ', function () {
 })
 suite.add('fast-safe-stringify:   large deep circular getters', function () {
   fastSafeStringify(deepCircGetters)
+})
+suite.add('fast-safe-stringify:   deepCircNonCongifurableGetters', function () {
+  fastSafeStringify(deepCircNonCongifurableGetters)
 })
 
 // add listeners

--- a/benchmark.js
+++ b/benchmark.js
@@ -59,69 +59,69 @@ Object.defineProperty(deepCircNonCongifurableGetters, 'array', {
   configurable: false
 })
 
-suite.add('util.inspect:          simple object              ', function () {
+suite.add('util.inspect:          simple object                 ', function () {
   inspect(obj, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          circular                   ', function () {
+suite.add('util.inspect:          circular                      ', function () {
   inspect(circ, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          circular getters           ', function () {
+suite.add('util.inspect:          circular getters              ', function () {
   inspect(circGetters, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          deep                       ', function () {
+suite.add('util.inspect:          deep                          ', function () {
   inspect(deep, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          deep circular              ', function () {
+suite.add('util.inspect:          deep circular                 ', function () {
   inspect(deepCirc, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          large deep circular getters', function () {
+suite.add('util.inspect:          large deep circular getters   ', function () {
   inspect(deepCircGetters, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          deepCircNonCongifurableGetters', function () {
+suite.add('util.inspect:          deep non-conf circular getters', function () {
   inspect(deepCircNonCongifurableGetters, { showHidden: false, depth: null })
 })
 
-suite.add('\njson-stringify-safe:   simple object              ', function () {
+suite.add('\njson-stringify-safe:   simple object                 ', function () {
   jsonStringifySafe(obj)
 })
-suite.add('json-stringify-safe:   circular                   ', function () {
+suite.add('json-stringify-safe:   circular                      ', function () {
   jsonStringifySafe(circ)
 })
-suite.add('json-stringify-safe:   circular getters           ', function () {
+suite.add('json-stringify-safe:   circular getters              ', function () {
   jsonStringifySafe(circGetters)
 })
-suite.add('json-stringify-safe:   deep                       ', function () {
+suite.add('json-stringify-safe:   deep                          ', function () {
   jsonStringifySafe(deep)
 })
-suite.add('json-stringify-safe:   deep circular              ', function () {
+suite.add('json-stringify-safe:   deep circular                 ', function () {
   jsonStringifySafe(deepCirc)
 })
-suite.add('json-stringify-safe:   large deep circular getters', function () {
+suite.add('json-stringify-safe:   large deep circular getters   ', function () {
   jsonStringifySafe(deepCircGetters)
 })
-suite.add('json-stringify-safe:   deepCircNonCongifurableGetters', function () {
+suite.add('json-stringify-safe:   deep non-conf circular getters', function () {
   jsonStringifySafe(deepCircNonCongifurableGetters)
 })
 
-suite.add('\nfast-safe-stringify:   simple object              ', function () {
+suite.add('\nfast-safe-stringify:   simple object                 ', function () {
   fastSafeStringify(obj)
 })
-suite.add('fast-safe-stringify:   circular                   ', function () {
+suite.add('fast-safe-stringify:   circular                      ', function () {
   fastSafeStringify(circ)
 })
-suite.add('fast-safe-stringify:   circular getters           ', function () {
+suite.add('fast-safe-stringify:   circular getters              ', function () {
   fastSafeStringify(circGetters)
 })
-suite.add('fast-safe-stringify:   deep                       ', function () {
+suite.add('fast-safe-stringify:   deep                          ', function () {
   fastSafeStringify(deep)
 })
-suite.add('fast-safe-stringify:   deep circular              ', function () {
+suite.add('fast-safe-stringify:   deep circular                 ', function () {
   fastSafeStringify(deepCirc)
 })
-suite.add('fast-safe-stringify:   large deep circular getters', function () {
+suite.add('fast-safe-stringify:   large deep circular getters   ', function () {
   fastSafeStringify(deepCircGetters)
 })
-suite.add('fast-safe-stringify:   deepCircNonCongifurableGetters', function () {
+suite.add('fast-safe-stringify:   deep non-conf circular getters', function () {
   fastSafeStringify(deepCircNonCongifurableGetters)
 })
 

--- a/benchmark.js
+++ b/benchmark.js
@@ -8,6 +8,9 @@ const array = new Array(10).fill(0).map((_, i) => i)
 const obj = { foo: array }
 const circ = JSON.parse(JSON.stringify(obj))
 circ.o = { obj: circ, array }
+const circGetters = JSON.parse(JSON.stringify(obj))
+Object.assign(circGetters, { get o () { return { obj: circGetters, array } } })
+
 const deep = require('./package.json')
 deep.deep = JSON.parse(JSON.stringify(deep))
 deep.deep.deep = JSON.parse(JSON.stringify(deep))
@@ -20,43 +23,75 @@ deepCirc.deep.deep.circ = deepCirc
 deepCirc.deep.circ = deepCirc
 deepCirc.array = array
 
-suite.add('util.inspect:          simple object', function () {
-  inspect(obj)
+const deepCircGetters = JSON.parse(JSON.stringify(deep))
+for (let i = 0; i < 10; i++) {
+  deepCircGetters[i.toString()] = {
+    deep: {
+      deep: {
+        get circ () { return deep.deep },
+        deep: { get circ () { return deep.deep.deep } }
+      },
+      get circ () { return deep }
+    },
+    get array () { return array }
+  }
+}
+
+suite.add('util.inspect:          simple object            ', function () {
+  inspect(obj, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          circular     ', function () {
-  inspect(circ)
+suite.add('util.inspect:          circular                 ', function () {
+  inspect(circ, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          deep         ', function () {
-  inspect(deep)
+suite.add('util.inspect:          circular getters         ', function () {
+  inspect(circGetters, { showHidden: false, depth: null })
 })
-suite.add('util.inspect:          deep circular', function () {
-  inspect(deepCirc)
+suite.add('util.inspect:          deep                     ', function () {
+  inspect(deep, { showHidden: false, depth: null })
+})
+suite.add('util.inspect:          deep circular            ', function () {
+  inspect(deepCirc, { showHidden: false, depth: null })
+})
+suite.add('util.inspect:          10+ deep circular getters', function () {
+  inspect(deepCircGetters, { showHidden: false, depth: null })
 })
 
-suite.add('\njson-stringify-safe:   simple object', function () {
+suite.add('\njson-stringify-safe:   simple object            ', function () {
   jsonStringifySafe(obj)
 })
-suite.add('json-stringify-safe:   circular     ', function () {
+suite.add('json-stringify-safe:   circular                 ', function () {
   jsonStringifySafe(circ)
 })
-suite.add('json-stringify-safe:   deep         ', function () {
+suite.add('json-stringify-safe:   circular getters         ', function () {
+  jsonStringifySafe(circGetters)
+})
+suite.add('json-stringify-safe:   deep                     ', function () {
   jsonStringifySafe(deep)
 })
-suite.add('json-stringify-safe:   deep circular', function () {
+suite.add('json-stringify-safe:   deep circular            ', function () {
   jsonStringifySafe(deepCirc)
 })
+suite.add('json-stringify-safe:   10+ deep circular getters', function () {
+  jsonStringifySafe(deepCircGetters)
+})
 
-suite.add('\nfast-safe-stringify:   simple object', function () {
+suite.add('\nfast-safe-stringify:   simple object            ', function () {
   fastSafeStringify(obj)
 })
-suite.add('fast-safe-stringify:   circular     ', function () {
+suite.add('fast-safe-stringify:   circular                 ', function () {
   fastSafeStringify(circ)
 })
-suite.add('fast-safe-stringify:   deep         ', function () {
+suite.add('fast-safe-stringify:   circular getters         ', function () {
+  fastSafeStringify(circGetters)
+})
+suite.add('fast-safe-stringify:   deep                     ', function () {
   fastSafeStringify(deep)
 })
-suite.add('fast-safe-stringify:   deep circular', function () {
+suite.add('fast-safe-stringify:   deep circular            ', function () {
   fastSafeStringify(deepCirc)
+})
+suite.add('fast-safe-stringify:   10+ deep circular getters', function () {
+  fastSafeStringify(deepCircGetters)
 })
 
 // add listeners

--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ function stringify (obj, replacer, spacer) {
   var res = JSON.stringify(obj, replacer, spacer)
   while (arr.length !== 0) {
     var part = arr.pop()
-    part[0][part[1]] = part[2]
+    if (part.length === 4) {
+      Object.defineProperty(part[0], part[1], part[3])
+    } else {
+      part[0][part[1]] = part[2]
+    }
   }
   return res
 }
@@ -20,12 +24,14 @@ function decirc (val, k, stack, parent) {
   if (typeof val === 'object' && val !== null) {
     for (i = 0; i < stack.length; i++) {
       if (stack[i] === val) {
-        if (Object.getOwnPropertyDescriptor(parent, k).get !== undefined) {
+        const propertyDescriptor = Object.getOwnPropertyDescriptor(parent, k)
+        if (propertyDescriptor.get !== undefined) {
           Object.defineProperty(parent, k, { value: '[Circular]' })
+          arr.push([parent, k, val, propertyDescriptor])
         } else {
           parent[k] = '[Circular]'
+          arr.push([parent, k, val])
         }
-        arr.push([parent, k, val])
         return
       }
     }
@@ -62,7 +68,11 @@ function deterministicStringify (obj, replacer, spacer) {
   var res = JSON.stringify(tmp, replacer, spacer)
   while (arr.length !== 0) {
     var part = arr.pop()
-    part[0][part[1]] = part[2]
+    if (part.length === 4) {
+      Object.defineProperty(part[0], part[1], part[3])
+    } else {
+      part[0][part[1]] = part[2]
+    }
   }
   return res
 }
@@ -72,12 +82,14 @@ function deterministicDecirc (val, k, stack, parent) {
   if (typeof val === 'object' && val !== null) {
     for (i = 0; i < stack.length; i++) {
       if (stack[i] === val) {
-        if (Object.getOwnPropertyDescriptor(parent, k).get !== undefined) {
+        const propertyDescriptor = Object.getOwnPropertyDescriptor(parent, k)
+        if (propertyDescriptor.get !== undefined) {
           Object.defineProperty(parent, k, { value: '[Circular]' })
+          arr.push([parent, k, val, propertyDescriptor])
         } else {
           parent[k] = '[Circular]'
+          arr.push([parent, k, val])
         }
-        arr.push([parent, k, val])
         return
       }
     }

--- a/index.js
+++ b/index.js
@@ -20,10 +20,11 @@ function decirc (val, k, stack, parent) {
   if (typeof val === 'object' && val !== null) {
     for (i = 0; i < stack.length; i++) {
       if (stack[i] === val) {
-        if (typeof Object.getOwnPropertyDescriptor(parent, k).get === 'function') {
-          delete parent[k]
+        if (Object.getOwnPropertyDescriptor(parent, k).get !== undefined) {
+          Object.defineProperty(parent, k, { value: '[Circular]' })
+        } else {
+          parent[k] = '[Circular]'
         }
-        parent[k] = '[Circular]'
         arr.push([parent, k, val])
         return
       }
@@ -71,7 +72,11 @@ function deterministicDecirc (val, k, stack, parent) {
   if (typeof val === 'object' && val !== null) {
     for (i = 0; i < stack.length; i++) {
       if (stack[i] === val) {
-        parent[k] = '[Circular]'
+        if (Object.getOwnPropertyDescriptor(parent, k).get !== undefined) {
+          Object.defineProperty(parent, k, { value: '[Circular]' })
+        } else {
+          parent[k] = '[Circular]'
+        }
         arr.push([parent, k, val])
         return
       }

--- a/index.js
+++ b/index.js
@@ -4,16 +4,16 @@ stringify.stable = deterministicStringify
 stringify.stableStringify = deterministicStringify
 
 var arr = []
-var nonConfigurables = []
+var replacerStack = []
 
 // Regular stringify
 function stringify (obj, replacer, spacer) {
   decirc(obj, '', [], undefined)
   var res
-  if (nonConfigurables.length === 0) {
+  if (replacerStack.length === 0) {
     res = JSON.stringify(obj, replacer, spacer)
   } else {
-    res = JSON.stringify(obj, handleNonConfigurableGetters(replacer), spacer)
+    res = JSON.stringify(obj, replaceGetterValues(replacer), spacer)
   }
   while (arr.length !== 0) {
     var part = arr.pop()
@@ -30,14 +30,13 @@ function decirc (val, k, stack, parent) {
   if (typeof val === 'object' && val !== null) {
     for (i = 0; i < stack.length; i++) {
       if (stack[i] === val) {
-        // Note: This doesn't handle circular sub-objects of non-configurable getters...
         var propertyDescriptor = Object.getOwnPropertyDescriptor(parent, k)
         if (propertyDescriptor.get !== undefined) {
           if (propertyDescriptor.configurable) {
             Object.defineProperty(parent, k, { value: '[Circular]' })
             arr.push([parent, k, val, propertyDescriptor])
           } else {
-            nonConfigurables.push([parent, k])
+            replacerStack.push([val, k])
           }
         } else {
           parent[k] = '[Circular]'
@@ -77,10 +76,10 @@ function compareFunction (a, b) {
 function deterministicStringify (obj, replacer, spacer) {
   var tmp = deterministicDecirc(obj, '', [], undefined) || obj
   var res
-  if (nonConfigurables.length === 0) {
+  if (replacerStack.length === 0) {
     res = JSON.stringify(tmp, replacer, spacer)
   } else {
-    res = JSON.stringify(tmp, handleNonConfigurableGetters(replacer), spacer)
+    res = JSON.stringify(tmp, replaceGetterValues(replacer), spacer)
   }
   while (arr.length !== 0) {
     var part = arr.pop()
@@ -98,14 +97,13 @@ function deterministicDecirc (val, k, stack, parent) {
   if (typeof val === 'object' && val !== null) {
     for (i = 0; i < stack.length; i++) {
       if (stack[i] === val) {
-        // Note: This doesn't handle circular sub-objects of non-configurable getters...
         var propertyDescriptor = Object.getOwnPropertyDescriptor(parent, k)
         if (propertyDescriptor.get !== undefined) {
           if (propertyDescriptor.configurable) {
             Object.defineProperty(parent, k, { value: '[Circular]' })
             arr.push([parent, k, val, propertyDescriptor])
           } else {
-            nonConfigurables.push([parent, k])
+            replacerStack.push([val, k])
           }
         } else {
           parent[k] = '[Circular]'
@@ -143,18 +141,17 @@ function deterministicDecirc (val, k, stack, parent) {
   }
 }
 
-// wraps replacer function to handle non-configurable getters
-// and sort of mark them as [Circular]
-function handleNonConfigurableGetters (replacer) {
-  replacer = replacer !== undefined ? replacer : (k, v) => v
+// wraps replacer function to handle values we couldn't replace
+// and mark them as [Circular]
+function replaceGetterValues (replacer) {
+  replacer = replacer !== undefined ? replacer : function (k, v) { return v }
   return function (key, val) {
-    if (nonConfigurables.length > 0) {
-      for (var i = 0; i < nonConfigurables.length; i++) {
-        var part = nonConfigurables[i]
-        // This references the parent object being stringified
-        if (part[1] === key && part[0] === this) {
+    if (replacerStack.length > 0) {
+      for (var i = 0; i < replacerStack.length; i++) {
+        var part = replacerStack[i]
+        if (part[1] === key && part[0] === val) {
           val = '[Circular]'
-          nonConfigurables.splice(i, 1)
+          replacerStack.splice(i, 1)
           break
         }
       }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ function decirc (val, k, stack, parent) {
   if (typeof val === 'object' && val !== null) {
     for (i = 0; i < stack.length; i++) {
       if (stack[i] === val) {
+        if (typeof Object.getOwnPropertyDescriptor(parent, k).get === 'function') {
+          delete parent[k]
+        }
         parent[k] = '[Circular]'
         arr.push([parent, k, val])
         return

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function decirc (val, k, stack, parent) {
     for (i = 0; i < stack.length; i++) {
       if (stack[i] === val) {
         // Note: This doesn't handle circular sub-objects of non-configurable getters...
-        const propertyDescriptor = Object.getOwnPropertyDescriptor(parent, k)
+        var propertyDescriptor = Object.getOwnPropertyDescriptor(parent, k)
         if (propertyDescriptor.get !== undefined) {
           if (propertyDescriptor.configurable) {
             Object.defineProperty(parent, k, { value: '[Circular]' })
@@ -99,7 +99,7 @@ function deterministicDecirc (val, k, stack, parent) {
     for (i = 0; i < stack.length; i++) {
       if (stack[i] === val) {
         // Note: This doesn't handle circular sub-objects of non-configurable getters...
-        const propertyDescriptor = Object.getOwnPropertyDescriptor(parent, k)
+        var propertyDescriptor = Object.getOwnPropertyDescriptor(parent, k)
         if (propertyDescriptor.get !== undefined) {
           if (propertyDescriptor.configurable) {
             Object.defineProperty(parent, k, { value: '[Circular]' })
@@ -149,8 +149,8 @@ function handleNonConfigurableGetters (replacer) {
   replacer = replacer !== undefined ? replacer : (k, v) => v
   return function (key, val) {
     if (nonConfigurables.length > 0) {
-      for (let i = 0; i < nonConfigurables.length; i++) {
-        const part = nonConfigurables[i]
+      for (var i = 0; i < nonConfigurables.length; i++) {
+        var part = nonConfigurables[i]
         // This references the parent object being stringified
         if (part[1] === key && part[0] === this) {
           val = '[Circular]'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "standard && tap test.js test-stable.js",
+    "test": "standard && tap --no-esm test.js test-stable.js",
     "benchmark": "node benchmark.js"
   },
   "author": "David Mark Clements",

--- a/test-stable.js
+++ b/test-stable.js
@@ -260,3 +260,16 @@ test('nested child circular reference in toJSON', function (assert) {
   assert.is(actual, expected)
   assert.end()
 })
+
+test('circular getters are restored when stringified', function (assert) {
+  const fixture = {
+    name: 'Tywin Lannister',
+    get circle () {
+      return fixture
+    }
+  }
+  fss(fixture)
+
+  assert.is(fixture.circle, fixture)
+  assert.end()
+})

--- a/test-stable.js
+++ b/test-stable.js
@@ -273,3 +273,17 @@ test('circular getters are restored when stringified', function (assert) {
   assert.is(fixture.circle, fixture)
   assert.end()
 })
+
+test('non-configurable circular getters use a replacer instead of markers', function (assert) {
+  const fixture = { name: 'Tywin Lannister' }
+  Object.defineProperty(fixture, 'circle', {
+    configurable: false,
+    get: function () { return fixture },
+    enumerable: true
+  })
+
+  fss(fixture)
+
+  assert.is(fixture.circle, fixture)
+  assert.end()
+})

--- a/test-stable.js
+++ b/test-stable.js
@@ -14,6 +14,22 @@ test('circular reference to root', function (assert) {
   assert.end()
 })
 
+test('circular getter reference to root', function (assert) {
+  const fixture = {
+    name: 'Tywin Lannister',
+    get circle () {
+      return fixture
+    }
+  }
+
+  const expected = s(
+    { circle: '[Circular]', name: 'Tywin Lannister' }
+  )
+  const actual = fss(fixture)
+  assert.is(actual, expected)
+  assert.end()
+})
+
 test('nested circular reference to root', function (assert) {
   const fixture = { name: 'Tywin Lannister' }
   fixture.id = { circle: fixture }

--- a/test-stable.js
+++ b/test-stable.js
@@ -287,3 +287,25 @@ test('non-configurable circular getters use a replacer instead of markers', func
   assert.is(fixture.circle, fixture)
   assert.end()
 })
+
+test('getter child circular reference', function (assert) {
+  const fixture = {
+    name: 'Tywin Lannister',
+    child: {
+      name: 'Tyrion Lannister',
+      get dinklage () { return fixture.child }
+    },
+    get self () { return fixture }
+  }
+
+  const expected = s({
+    child: {
+      dinklage: '[Circular]', name: 'Tyrion Lannister'
+    },
+    name: 'Tywin Lannister',
+    self: '[Circular]'
+  })
+  const actual = fss(fixture)
+  assert.is(actual, expected)
+  assert.end()
+})

--- a/test.js
+++ b/test.js
@@ -14,6 +14,21 @@ test('circular reference to root', function (assert) {
   assert.end()
 })
 
+test('circular getter reference to root', function (assert) {
+  const fixture = {
+    name: 'Tywin Lannister',
+    get circle () {
+      return fixture
+    }
+  }
+  const expected = s(
+    { name: 'Tywin Lannister', circle: '[Circular]' }
+  )
+  const actual = fss(fixture)
+  assert.is(actual, expected)
+  assert.end()
+})
+
 test('nested circular reference to root', function (assert) {
   const fixture = { name: 'Tywin Lannister' }
   fixture.id = { circle: fixture }

--- a/test.js
+++ b/test.js
@@ -266,3 +266,17 @@ test('circular getters are restored when stringified', function (assert) {
   assert.is(fixture.circle, fixture)
   assert.end()
 })
+
+test('non-configurable circular getters use a replacer instead of markers', function (assert) {
+  const fixture = { name: 'Tywin Lannister' }
+  Object.defineProperty(fixture, 'circle', {
+    configurable: false,
+    get: function () { return fixture },
+    enumerable: true
+  })
+
+  fss(fixture)
+
+  assert.is(fixture.circle, fixture)
+  assert.end()
+})

--- a/test.js
+++ b/test.js
@@ -253,3 +253,16 @@ test('nested child circular reference in toJSON', function (assert) {
   assert.is(actual, expected)
   assert.end()
 })
+
+test('circular getters are restored when stringified', function (assert) {
+  const fixture = {
+    name: 'Tywin Lannister',
+    get circle () {
+      return fixture
+    }
+  }
+  fss(fixture)
+
+  assert.is(fixture.circle, fixture)
+  assert.end()
+})

--- a/test.js
+++ b/test.js
@@ -280,3 +280,25 @@ test('non-configurable circular getters use a replacer instead of markers', func
   assert.is(fixture.circle, fixture)
   assert.end()
 })
+
+test('getter child circular reference are replaced instead of marked', function (assert) {
+  const fixture = {
+    name: 'Tywin Lannister',
+    child: {
+      name: 'Tyrion Lannister',
+      get dinklage () { return fixture.child }
+    },
+    get self () { return fixture }
+  }
+
+  const expected = s({
+    name: 'Tywin Lannister',
+    child: {
+      name: 'Tyrion Lannister', dinklage: '[Circular]'
+    },
+    self: '[Circular]'
+  })
+  const actual = fss(fixture)
+  assert.is(actual, expected)
+  assert.end()
+})


### PR DESCRIPTION
Hello!

Fixes #44 

In short, this fixes an issue where circular references in getters weren't replaced in `decirc` which threw the error`TypeError: Converting circular structure to JSON` when eventually passed to `JSON.stringify`. To not have that problem, I remove the property and set it to `'[Circular]'` since straight up setting it won't work (unless it has a defined setter).

Example object that threw before:

```javascript
const o = {
  a: 1,
  get self() {
    return o
  },
}
```

Let me know if there's anything else I can do to try to remediate this. :)

I ran the benchmarks which yielded the below results. I wouldn't trust them fully though as I'd have expected my changes to have been objectively slower on all cases? Results seems to be close enough though, I believe?

**Before**:

```
util.inspect:          simple object x 43,740 ops/sec ±0.45% (88 runs sampled)
util.inspect:          circular      x 21,473 ops/sec ±0.64% (92 runs sampled)
util.inspect:          deep          x 3,067 ops/sec ±0.77% (93 runs sampled)
util.inspect:          deep circular x 3,054 ops/sec ±0.59% (92 runs sampled)

json-stringify-safe:   simple object x 335,428 ops/sec ±1.22% (92 runs sampled)
json-stringify-safe:   circular      x 148,669 ops/sec ±0.74% (90 runs sampled)
json-stringify-safe:   deep          x 8,256 ops/sec ±1.04% (91 runs sampled)
json-stringify-safe:   deep circular x 8,160 ops/sec ±0.66% (90 runs sampled)

fast-safe-stringify:   simple object x 1,140,411 ops/sec ±0.62% (92 runs sampled)
fast-safe-stringify:   circular      x 604,163 ops/sec ±0.67% (93 runs sampled)
fast-safe-stringify:   deep          x 38,762 ops/sec ±0.88% (91 runs sampled)
fast-safe-stringify:   deep circular x 38,023 ops/sec ±0.64% (94 runs sampled)

Fastest is
fast-safe-stringify:   simple object
```
---

**After**:

```
util.inspect:          simple object x 45,068 ops/sec ±0.53% (86 runs sampled)
util.inspect:          circular      x 22,214 ops/sec ±0.82% (88 runs sampled)
util.inspect:          deep          x 3,239 ops/sec ±0.70% (93 runs sampled)
util.inspect:          deep circular x 3,191 ops/sec ±0.93% (92 runs sampled)

json-stringify-safe:   simple object x 347,556 ops/sec ±0.70% (92 runs sampled)
json-stringify-safe:   circular      x 154,494 ops/sec ±0.68% (91 runs sampled)
json-stringify-safe:   deep          x 8,541 ops/sec ±0.64% (94 runs sampled)
json-stringify-safe:   deep circular x 8,342 ops/sec ±0.76% (91 runs sampled)

fast-safe-stringify:   simple object x 1,144,744 ops/sec ±0.51% (92 runs sampled)
fast-safe-stringify:   circular      x 557,971 ops/sec ±0.97% (93 runs sampled)
fast-safe-stringify:   deep          x 38,949 ops/sec ±0.60% (92 runs sampled)
fast-safe-stringify:   deep circular x 37,684 ops/sec ±0.65% (92 runs sampled)

Fastest is
fast-safe-stringify:   simple object
```