### PR TITLE
fix: add array values to stack to fix decirc hang

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ function decirc (val, k, stack, parent) {
     // Optimize for Arrays. Big arrays could kill the performance otherwise!
     if (Array.isArray(val)) {
       for (i = 0; i < val.length; i++) {
+        stack.push(val[i])
         decirc(val[i], i, stack, val)
+        stack.pop()
       }
     } else {
       var keys = Object.keys(val)


### PR DESCRIPTION
Add items in array to stack prior to calling `decirc` to fix problems with deep nesting, reported in https://github.com/pinojs/pino/issues/990