### PR TITLE
fix: add max depth limit and max edges limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v.2.1.0
+
+Features
+
+- Added optional parameter options - depthLimit and edgesLimit
+- Added default options.depthLimit 10
+- Added default options.edgesLimit 20
+
 ## v.2.0.0
 
 Features

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare function stringify(
   value: any,
   replacer?: (key: string, value: any) => any,
   space?: string | number,
-  options?: { depthLimit: number; edgesLimit: number }
+  options?: { depthLimit: number | undefined; edgesLimit: number | undefined }
 ): string;
 
 declare namespace stringify {
@@ -10,13 +10,13 @@ declare namespace stringify {
     value: any,
     replacer?: (key: string, value: any) => any,
     space?: string | number,
-    options?: { depthLimit: number; edgesLimit: number }
+    options?: { depthLimit: number | undefined; edgesLimit: number | undefined }
   ): string;
   export function stableStringify(
     value: any,
     replacer?: (key: string, value: any) => any,
     space?: string | number,
-    options?: { depthLimit: number; edgesLimit: number }
+    options?: { depthLimit: number | undefined; edgesLimit: number | undefined }
   ): string;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,23 @@
-declare function stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string;
+declare function stringify(
+  value: any,
+  replacer?: (key: string, value: any) => any,
+  space?: string | number,
+  options?: { depthLimit: number; edgesLimit: number }
+): string;
 
 declare namespace stringify {
-  export function stable(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string;
-  export function stableStringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string;
+  export function stable(
+    value: any,
+    replacer?: (key: string, value: any) => any,
+    space?: string | number,
+    options?: { depthLimit: number; edgesLimit: number }
+  ): string;
+  export function stableStringify(
+    value: any,
+    replacer?: (key: string, value: any) => any,
+    space?: string | number,
+    options?: { depthLimit: number; edgesLimit: number }
+  ): string;
 }
 
 export default stringify;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ stringify.default = stringify
 stringify.stable = deterministicStringify
 stringify.stableStringify = deterministicStringify
 
-var LIMIT_REPLACE_NODE = '...'
+var LIMIT_REPLACE_NODE = '[...]'
 var CIRCULAR_REPLACE_NODE = '[Circular]'
 
 var arr = []
@@ -76,7 +76,7 @@ function decirc (val, k, edgeIndex, stack, parent, depth, options) {
 
     if (
       typeof options.edgesLimit !== 'undefined' &&
-      edgeIndex > options.edgeLimit
+      edgeIndex + 1 > options.edgesLimit
     ) {
       setReplace(LIMIT_REPLACE_NODE, val, k, parent)
       return
@@ -158,7 +158,7 @@ function deterministicDecirc (val, k, edgeIndex, stack, parent, depth, options) 
 
     if (
       typeof options.edgesLimit !== 'undefined' &&
-      edgeIndex > options.edgeLimit
+      edgeIndex + 1 > options.edgesLimit
     ) {
       setReplace(LIMIT_REPLACE_NODE, val, k, parent)
       return

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-safe-stringify",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "Safely and quickly serialize JavaScript objects",
   "keywords": [
     "stable",

--- a/readme.md
+++ b/readme.md
@@ -11,31 +11,37 @@ handle circular structures. See the example below for further information.
 
 The same as [JSON.stringify][].
 
-`stringify(value[, replacer[, space]])`
+`stringify(value[, replacer[, space[, options]]])`
 
 ```js
-const safeStringify = require('fast-safe-stringify')
-const o = { a: 1 }
-o.o = o
+const safeStringify = require("fast-safe-stringify");
+const o = { a: 1 };
+o.o = o;
 
-console.log(safeStringify(o))
+console.log(safeStringify(o));
 // '{"a":1,"o":"[Circular]"}'
-console.log(JSON.stringify(o))
+console.log(JSON.stringify(o));
 // TypeError: Converting circular structure to JSON
 
 function replacer(key, value) {
-  console.log('Key:', JSON.stringify(key), 'Value:', JSON.stringify(value))
+  console.log("Key:", JSON.stringify(key), "Value:", JSON.stringify(value));
   // Remove the circular structure
-  if (value === '[Circular]') {
-    return
+  if (value === "[Circular]") {
+    return;
   }
-  return value
+  return value;
 }
-const serialized = safeStringify(o, replacer, 2)
+// those are also defaults limits when no options object is passed into safeStringify
+const options = {
+  depthLimit: 10,
+  edgesLimit: 20,
+};
+
+const serialized = safeStringify(o, replacer, 2, options);
 // Key: "" Value: {"a":1,"o":"[Circular]"}
 // Key: "a" Value: 1
 // Key: "o" Value: "[Circular]"
-console.log(serialized)
+console.log(serialized);
 // {
 //  "a": 1
 // }
@@ -44,21 +50,26 @@ console.log(serialized)
 Using the deterministic version also works the same:
 
 ```js
-const safeStringify = require('fast-safe-stringify')
-const o = { b: 1, a: 0 }
-o.o = o
+const safeStringify = require("fast-safe-stringify");
+const o = { b: 1, a: 0 };
+o.o = o;
 
-console.log(safeStringify(o))
+console.log(safeStringify(o));
 // '{"b":1,"a":0,"o":"[Circular]"}'
-console.log(safeStringify.stableStringify(o))
+console.log(safeStringify.stableStringify(o));
 // '{"a":0,"b":1,"o":"[Circular]"}'
-console.log(JSON.stringify(o))
+console.log(JSON.stringify(o));
 // TypeError: Converting circular structure to JSON
 ```
 
 A faster and side-effect free implementation is available in the
 [safe-stable-stringify][] module. However it is still considered experimental
 due to a new and more complex implementation.
+
+### Replace strings constants
+
+- `[Circular]` - when same reference is found
+- `[...]` - when some limit from options object is reached
 
 ## Differences to JSON.stringify
 
@@ -101,20 +112,20 @@ Here we compare `fast-safe-stringify` with some alternatives:
 (Lenovo T450s with a i7-5600U CPU using Node.js 8.9.4)
 
 ```md
-fast-safe-stringify:   simple object x 1,121,497 ops/sec ±0.75% (97 runs sampled)
-fast-safe-stringify:   circular      x 560,126 ops/sec ±0.64% (96 runs sampled)
-fast-safe-stringify:   deep          x 32,472 ops/sec ±0.57% (95 runs sampled)
-fast-safe-stringify:   deep circular x 32,513 ops/sec ±0.80% (92 runs sampled)
+fast-safe-stringify: simple object x 1,121,497 ops/sec ±0.75% (97 runs sampled)
+fast-safe-stringify: circular x 560,126 ops/sec ±0.64% (96 runs sampled)
+fast-safe-stringify: deep x 32,472 ops/sec ±0.57% (95 runs sampled)
+fast-safe-stringify: deep circular x 32,513 ops/sec ±0.80% (92 runs sampled)
 
-util.inspect:          simple object x 272,837 ops/sec ±1.48% (90 runs sampled)
-util.inspect:          circular      x 116,896 ops/sec ±1.19% (95 runs sampled)
-util.inspect:          deep          x 19,382 ops/sec ±0.66% (92 runs sampled)
-util.inspect:          deep circular x 18,717 ops/sec ±0.63% (96 runs sampled)
+util.inspect: simple object x 272,837 ops/sec ±1.48% (90 runs sampled)
+util.inspect: circular x 116,896 ops/sec ±1.19% (95 runs sampled)
+util.inspect: deep x 19,382 ops/sec ±0.66% (92 runs sampled)
+util.inspect: deep circular x 18,717 ops/sec ±0.63% (96 runs sampled)
 
-json-stringify-safe:   simple object x 233,621 ops/sec ±0.97% (94 runs sampled)
-json-stringify-safe:   circular      x 110,409 ops/sec ±1.85% (95 runs sampled)
-json-stringify-safe:   deep          x 8,705 ops/sec ±0.87% (96 runs sampled)
-json-stringify-safe:   deep circular x 8,336 ops/sec ±2.20% (93 runs sampled)
+json-stringify-safe: simple object x 233,621 ops/sec ±0.97% (94 runs sampled)
+json-stringify-safe: circular x 110,409 ops/sec ±1.85% (95 runs sampled)
+json-stringify-safe: deep x 8,705 ops/sec ±0.87% (96 runs sampled)
+json-stringify-safe: deep circular x 8,336 ops/sec ±2.20% (93 runs sampled)
 ```
 
 For stable stringify comparisons, see the performance benchmarks in the
@@ -129,13 +140,15 @@ Shallow or one level nested objects on the other hand will slow down with it.
 It is entirely dependant on the use case.
 
 ```js
-const stringify = require('fast-safe-stringify')
+const stringify = require("fast-safe-stringify");
 
-function tryJSONStringify (obj) {
-  try { return JSON.stringify(obj) } catch (_) {}
+function tryJSONStringify(obj) {
+  try {
+    return JSON.stringify(obj);
+  } catch (_) {}
 }
 
-const serializedString = tryJSONStringify(deep) || stringify(deep)
+const serializedString = tryJSONStringify(deep) || stringify(deep);
 ```
 
 ## Acknowledgements
@@ -149,6 +162,6 @@ MIT
 [`replacer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The%20replacer%20parameter
 [`safe-stable-stringify`]: https://github.com/BridgeAR/safe-stable-stringify
 [`space`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The%20space%20argument
-[`toJSON`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
+[`tojson`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
 [benchmark]: https://github.com/epoberezkin/fast-json-stable-stringify/blob/67f688f7441010cfef91a6147280cc501701e83b/benchmark
-[JSON.stringify]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+[json.stringify]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify

--- a/readme.md
+++ b/readme.md
@@ -14,51 +14,53 @@ The same as [JSON.stringify][].
 `stringify(value[, replacer[, space[, options]]])`
 
 ```js
-const safeStringify = require("fast-safe-stringify");
-const o = { a: 1 };
-o.o = o;
+const safeStringify = require('fast-safe-stringify')
+const o = { a: 1 }
+o.o = o
 
-console.log(safeStringify(o));
+console.log(safeStringify(o))
 // '{"a":1,"o":"[Circular]"}'
-console.log(JSON.stringify(o));
+console.log(JSON.stringify(o))
 // TypeError: Converting circular structure to JSON
 
 function replacer(key, value) {
-  console.log("Key:", JSON.stringify(key), "Value:", JSON.stringify(value));
+  console.log('Key:', JSON.stringify(key), 'Value:', JSON.stringify(value))
   // Remove the circular structure
-  if (value === "[Circular]") {
-    return;
+  if (value === '[Circular]') {
+    return
   }
-  return value;
+  return value
 }
+
 // those are also defaults limits when no options object is passed into safeStringify
 const options = {
   depthLimit: 10,
   edgesLimit: 20,
 };
 
-const serialized = safeStringify(o, replacer, 2, options);
+const serialized = safeStringify(o, replacer, 2, options)
 // Key: "" Value: {"a":1,"o":"[Circular]"}
 // Key: "a" Value: 1
 // Key: "o" Value: "[Circular]"
-console.log(serialized);
+console.log(serialized)
 // {
 //  "a": 1
 // }
 ```
 
+
 Using the deterministic version also works the same:
 
 ```js
-const safeStringify = require("fast-safe-stringify");
-const o = { b: 1, a: 0 };
-o.o = o;
+const safeStringify = require('fast-safe-stringify')
+const o = { b: 1, a: 0 }
+o.o = o
 
-console.log(safeStringify(o));
+console.log(safeStringify(o))
 // '{"b":1,"a":0,"o":"[Circular]"}'
-console.log(safeStringify.stableStringify(o));
+console.log(safeStringify.stableStringify(o))
 // '{"a":0,"b":1,"o":"[Circular]"}'
-console.log(JSON.stringify(o));
+console.log(JSON.stringify(o))
 // TypeError: Converting circular structure to JSON
 ```
 
@@ -112,20 +114,20 @@ Here we compare `fast-safe-stringify` with some alternatives:
 (Lenovo T450s with a i7-5600U CPU using Node.js 8.9.4)
 
 ```md
-fast-safe-stringify: simple object x 1,121,497 ops/sec ±0.75% (97 runs sampled)
-fast-safe-stringify: circular x 560,126 ops/sec ±0.64% (96 runs sampled)
-fast-safe-stringify: deep x 32,472 ops/sec ±0.57% (95 runs sampled)
-fast-safe-stringify: deep circular x 32,513 ops/sec ±0.80% (92 runs sampled)
+fast-safe-stringify:   simple object x 1,121,497 ops/sec ±0.75% (97 runs sampled)
+fast-safe-stringify:   circular      x 560,126 ops/sec ±0.64% (96 runs sampled)
+fast-safe-stringify:   deep          x 32,472 ops/sec ±0.57% (95 runs sampled)
+fast-safe-stringify:   deep circular x 32,513 ops/sec ±0.80% (92 runs sampled)
 
-util.inspect: simple object x 272,837 ops/sec ±1.48% (90 runs sampled)
-util.inspect: circular x 116,896 ops/sec ±1.19% (95 runs sampled)
-util.inspect: deep x 19,382 ops/sec ±0.66% (92 runs sampled)
-util.inspect: deep circular x 18,717 ops/sec ±0.63% (96 runs sampled)
+util.inspect:          simple object x 272,837 ops/sec ±1.48% (90 runs sampled)
+util.inspect:          circular      x 116,896 ops/sec ±1.19% (95 runs sampled)
+util.inspect:          deep          x 19,382 ops/sec ±0.66% (92 runs sampled)
+util.inspect:          deep circular x 18,717 ops/sec ±0.63% (96 runs sampled)
 
-json-stringify-safe: simple object x 233,621 ops/sec ±0.97% (94 runs sampled)
-json-stringify-safe: circular x 110,409 ops/sec ±1.85% (95 runs sampled)
-json-stringify-safe: deep x 8,705 ops/sec ±0.87% (96 runs sampled)
-json-stringify-safe: deep circular x 8,336 ops/sec ±2.20% (93 runs sampled)
+json-stringify-safe:   simple object x 233,621 ops/sec ±0.97% (94 runs sampled)
+json-stringify-safe:   circular      x 110,409 ops/sec ±1.85% (95 runs sampled)
+json-stringify-safe:   deep          x 8,705 ops/sec ±0.87% (96 runs sampled)
+json-stringify-safe:   deep circular x 8,336 ops/sec ±2.20% (93 runs sampled)
 ```
 
 For stable stringify comparisons, see the performance benchmarks in the
@@ -140,15 +142,13 @@ Shallow or one level nested objects on the other hand will slow down with it.
 It is entirely dependant on the use case.
 
 ```js
-const stringify = require("fast-safe-stringify");
+const stringify = require('fast-safe-stringify')
 
-function tryJSONStringify(obj) {
-  try {
-    return JSON.stringify(obj);
-  } catch (_) {}
+function tryJSONStringify (obj) {
+  try { return JSON.stringify(obj) } catch (_) {}
 }
 
-const serializedString = tryJSONStringify(deep) || stringify(deep);
+const serializedString = tryJSONStringify(deep) || stringify(deep)
 ```
 
 ## Acknowledgements
@@ -162,6 +162,6 @@ MIT
 [`replacer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The%20replacer%20parameter
 [`safe-stable-stringify`]: https://github.com/BridgeAR/safe-stable-stringify
 [`space`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The%20space%20argument
-[`tojson`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
+[`toJSON`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
 [benchmark]: https://github.com/epoberezkin/fast-json-stable-stringify/blob/67f688f7441010cfef91a6147280cc501701e83b/benchmark
-[json.stringify]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+[JSON.stringify]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify

--- a/test-stable.js
+++ b/test-stable.js
@@ -6,9 +6,7 @@ const s = JSON.stringify
 test('circular reference to root', function (assert) {
   const fixture = { name: 'Tywin Lannister' }
   fixture.circle = fixture
-  const expected = s(
-    { circle: '[Circular]', name: 'Tywin Lannister' }
-  )
+  const expected = s({ circle: '[Circular]', name: 'Tywin Lannister' })
   const actual = fss(fixture)
   assert.is(actual, expected)
   assert.end()
@@ -22,9 +20,7 @@ test('circular getter reference to root', function (assert) {
     }
   }
 
-  const expected = s(
-    { circle: '[Circular]', name: 'Tywin Lannister' }
-  )
+  const expected = s({ circle: '[Circular]', name: 'Tywin Lannister' })
   const actual = fss(fixture)
   assert.is(actual, expected)
   assert.end()
@@ -33,20 +29,22 @@ test('circular getter reference to root', function (assert) {
 test('nested circular reference to root', function (assert) {
   const fixture = { name: 'Tywin Lannister' }
   fixture.id = { circle: fixture }
-  const expected = s(
-    { id: { circle: '[Circular]' }, name: 'Tywin Lannister' }
-  )
+  const expected = s({ id: { circle: '[Circular]' }, name: 'Tywin Lannister' })
   const actual = fss(fixture)
   assert.is(actual, expected)
   assert.end()
 })
 
 test('child circular reference', function (assert) {
-  const fixture = { name: 'Tywin Lannister', child: { name: 'Tyrion Lannister' } }
+  const fixture = {
+    name: 'Tywin Lannister',
+    child: { name: 'Tyrion Lannister' }
+  }
   fixture.child.dinklage = fixture.child
   const expected = s({
     child: {
-      dinklage: '[Circular]', name: 'Tyrion Lannister'
+      dinklage: '[Circular]',
+      name: 'Tyrion Lannister'
     },
     name: 'Tywin Lannister'
   })
@@ -56,11 +54,15 @@ test('child circular reference', function (assert) {
 })
 
 test('nested child circular reference', function (assert) {
-  const fixture = { name: 'Tywin Lannister', child: { name: 'Tyrion Lannister' } }
+  const fixture = {
+    name: 'Tywin Lannister',
+    child: { name: 'Tyrion Lannister' }
+  }
   fixture.child.actor = { dinklage: fixture.child }
   const expected = s({
     child: {
-      actor: { dinklage: '[Circular]' }, name: 'Tyrion Lannister'
+      actor: { dinklage: '[Circular]' },
+      name: 'Tyrion Lannister'
     },
     name: 'Tywin Lannister'
   })
@@ -73,7 +75,8 @@ test('circular objects in an array', function (assert) {
   const fixture = { name: 'Tywin Lannister' }
   fixture.hand = [fixture, fixture]
   const expected = s({
-    hand: ['[Circular]', '[Circular]'], name: 'Tywin Lannister'
+    hand: ['[Circular]', '[Circular]'],
+    name: 'Tywin Lannister'
   })
   const actual = fss(fixture)
   assert.is(actual, expected)
@@ -155,10 +158,12 @@ test('double child circular reference', function (assert) {
   const cloned = clone(fixture)
   const expected = s({
     childA: {
-      dinklage: '[Circular]', name: 'Tyrion Lannister'
+      dinklage: '[Circular]',
+      name: 'Tyrion Lannister'
     },
     childB: {
-      dinklage: '[Circular]', name: 'Tyrion Lannister'
+      dinklage: '[Circular]',
+      name: 'Tyrion Lannister'
     },
     name: 'Tywin Lannister'
   })
@@ -172,7 +177,9 @@ test('double child circular reference', function (assert) {
 
 test('child circular reference with toJSON', function (assert) {
   // Create a test object that has an overriden `toJSON` property
-  TestObject.prototype.toJSON = function () { return { special: 'case' } }
+  TestObject.prototype.toJSON = function () {
+    return { special: 'case' }
+  }
   function TestObject (content) {}
 
   // Creating a simple circular object structure
@@ -187,7 +194,10 @@ test('child circular reference with toJSON', function (assert) {
 
   // Making sure our original tests work
   assert.deepEqual(parentObject.childObject.parentObject, parentObject)
-  assert.deepEqual(otherParentObject.otherChildObject.otherParentObject, otherParentObject)
+  assert.deepEqual(
+    otherParentObject.otherChildObject.otherParentObject,
+    otherParentObject
+  )
 
   // Should both be idempotent
   assert.equal(fss(parentObject), '{"childObject":{"special":"case"}}')
@@ -195,7 +205,10 @@ test('child circular reference with toJSON', function (assert) {
 
   // Therefore the following assertion should be `true`
   assert.deepEqual(parentObject.childObject.parentObject, parentObject)
-  assert.deepEqual(otherParentObject.otherChildObject.otherParentObject, otherParentObject)
+  assert.deepEqual(
+    otherParentObject.otherChildObject.otherParentObject,
+    otherParentObject
+  )
 
   assert.end()
 })
@@ -278,7 +291,9 @@ test('non-configurable circular getters use a replacer instead of markers', func
   const fixture = { name: 'Tywin Lannister' }
   Object.defineProperty(fixture, 'circle', {
     configurable: false,
-    get: function () { return fixture },
+    get: function () {
+      return fixture
+    },
     enumerable: true
   })
 
@@ -293,19 +308,85 @@ test('getter child circular reference', function (assert) {
     name: 'Tywin Lannister',
     child: {
       name: 'Tyrion Lannister',
-      get dinklage () { return fixture.child }
+      get dinklage () {
+        return fixture.child
+      }
     },
-    get self () { return fixture }
+    get self () {
+      return fixture
+    }
   }
 
   const expected = s({
     child: {
-      dinklage: '[Circular]', name: 'Tyrion Lannister'
+      dinklage: '[Circular]',
+      name: 'Tyrion Lannister'
     },
     name: 'Tywin Lannister',
     self: '[Circular]'
   })
   const actual = fss(fixture)
+  assert.is(actual, expected)
+  assert.end()
+})
+
+test('depthLimit option - will replace deep objects', function (assert) {
+  const fixture = {
+    name: 'Tywin Lannister',
+    child: {
+      name: 'Tyrion Lannister'
+    },
+    get self () {
+      return fixture
+    }
+  }
+
+  const expected = s({
+    child: '[...]',
+    name: 'Tywin Lannister',
+    self: '[Circular]'
+  })
+  const actual = fss(fixture, undefined, undefined, {
+    depthLimit: 1,
+    edgesLimit: 1
+  })
+  assert.is(actual, expected)
+  assert.end()
+})
+
+test('edgesLimit option - will replace deep objects', function (assert) {
+  const fixture = {
+    object: {
+      1: { test: 'test' },
+      2: { test: 'test' },
+      3: { test: 'test' },
+      4: { test: 'test' }
+    },
+    array: [
+      { test: 'test' },
+      { test: 'test' },
+      { test: 'test' },
+      { test: 'test' }
+    ],
+    get self () {
+      return fixture
+    }
+  }
+
+  const expected = s({
+    array: [{ test: 'test' }, { test: 'test' }, { test: 'test' }, '[...]'],
+    object: {
+      1: { test: 'test' },
+      2: { test: 'test' },
+      3: { test: 'test' },
+      4: '[...]'
+    },
+    self: '[Circular]'
+  })
+  const actual = fss(fixture, undefined, undefined, {
+    depthLimit: 3,
+    edgesLimit: 3
+  })
   assert.is(actual, expected)
   assert.end()
 })

--- a/test.js
+++ b/test.js
@@ -6,9 +6,7 @@ const s = JSON.stringify
 test('circular reference to root', function (assert) {
   const fixture = { name: 'Tywin Lannister' }
   fixture.circle = fixture
-  const expected = s(
-    { name: 'Tywin Lannister', circle: '[Circular]' }
-  )
+  const expected = s({ name: 'Tywin Lannister', circle: '[Circular]' })
   const actual = fss(fixture)
   assert.is(actual, expected)
   assert.end()
@@ -21,9 +19,7 @@ test('circular getter reference to root', function (assert) {
       return fixture
     }
   }
-  const expected = s(
-    { name: 'Tywin Lannister', circle: '[Circular]' }
-  )
+  const expected = s({ name: 'Tywin Lannister', circle: '[Circular]' })
   const actual = fss(fixture)
   assert.is(actual, expected)
   assert.end()
@@ -32,21 +28,23 @@ test('circular getter reference to root', function (assert) {
 test('nested circular reference to root', function (assert) {
   const fixture = { name: 'Tywin Lannister' }
   fixture.id = { circle: fixture }
-  const expected = s(
-    { name: 'Tywin Lannister', id: { circle: '[Circular]' } }
-  )
+  const expected = s({ name: 'Tywin Lannister', id: { circle: '[Circular]' } })
   const actual = fss(fixture)
   assert.is(actual, expected)
   assert.end()
 })
 
 test('child circular reference', function (assert) {
-  const fixture = { name: 'Tywin Lannister', child: { name: 'Tyrion Lannister' } }
+  const fixture = {
+    name: 'Tywin Lannister',
+    child: { name: 'Tyrion Lannister' }
+  }
   fixture.child.dinklage = fixture.child
   const expected = s({
     name: 'Tywin Lannister',
     child: {
-      name: 'Tyrion Lannister', dinklage: '[Circular]'
+      name: 'Tyrion Lannister',
+      dinklage: '[Circular]'
     }
   })
   const actual = fss(fixture)
@@ -55,12 +53,16 @@ test('child circular reference', function (assert) {
 })
 
 test('nested child circular reference', function (assert) {
-  const fixture = { name: 'Tywin Lannister', child: { name: 'Tyrion Lannister' } }
+  const fixture = {
+    name: 'Tywin Lannister',
+    child: { name: 'Tyrion Lannister' }
+  }
   fixture.child.actor = { dinklage: fixture.child }
   const expected = s({
     name: 'Tywin Lannister',
     child: {
-      name: 'Tyrion Lannister', actor: { dinklage: '[Circular]' }
+      name: 'Tyrion Lannister',
+      actor: { dinklage: '[Circular]' }
     }
   })
   const actual = fss(fixture)
@@ -72,7 +74,8 @@ test('circular objects in an array', function (assert) {
   const fixture = { name: 'Tywin Lannister' }
   fixture.hand = [fixture, fixture]
   const expected = s({
-    name: 'Tywin Lannister', hand: ['[Circular]', '[Circular]']
+    name: 'Tywin Lannister',
+    hand: ['[Circular]', '[Circular]']
   })
   const actual = fss(fixture)
   assert.is(actual, expected)
@@ -155,10 +158,12 @@ test('double child circular reference', function (assert) {
   const expected = s({
     name: 'Tywin Lannister',
     childA: {
-      name: 'Tyrion Lannister', dinklage: '[Circular]'
+      name: 'Tyrion Lannister',
+      dinklage: '[Circular]'
     },
     childB: {
-      name: 'Tyrion Lannister', dinklage: '[Circular]'
+      name: 'Tyrion Lannister',
+      dinklage: '[Circular]'
     }
   })
   const actual = fss(fixture)
@@ -171,7 +176,9 @@ test('double child circular reference', function (assert) {
 
 test('child circular reference with toJSON', function (assert) {
   // Create a test object that has an overriden `toJSON` property
-  TestObject.prototype.toJSON = function () { return { special: 'case' } }
+  TestObject.prototype.toJSON = function () {
+    return { special: 'case' }
+  }
   function TestObject (content) {}
 
   // Creating a simple circular object structure
@@ -186,7 +193,10 @@ test('child circular reference with toJSON', function (assert) {
 
   // Making sure our original tests work
   assert.deepEqual(parentObject.childObject.parentObject, parentObject)
-  assert.deepEqual(otherParentObject.otherChildObject.otherParentObject, otherParentObject)
+  assert.deepEqual(
+    otherParentObject.otherChildObject.otherParentObject,
+    otherParentObject
+  )
 
   // Should both be idempotent
   assert.equal(fss(parentObject), '{"childObject":{"special":"case"}}')
@@ -194,7 +204,10 @@ test('child circular reference with toJSON', function (assert) {
 
   // Therefore the following assertion should be `true`
   assert.deepEqual(parentObject.childObject.parentObject, parentObject)
-  assert.deepEqual(otherParentObject.otherChildObject.otherParentObject, otherParentObject)
+  assert.deepEqual(
+    otherParentObject.otherChildObject.otherParentObject,
+    otherParentObject
+  )
 
   assert.end()
 })
@@ -271,7 +284,9 @@ test('non-configurable circular getters use a replacer instead of markers', func
   const fixture = { name: 'Tywin Lannister' }
   Object.defineProperty(fixture, 'circle', {
     configurable: false,
-    get: function () { return fixture },
+    get: function () {
+      return fixture
+    },
     enumerable: true
   })
 
@@ -286,19 +301,85 @@ test('getter child circular reference are replaced instead of marked', function 
     name: 'Tywin Lannister',
     child: {
       name: 'Tyrion Lannister',
-      get dinklage () { return fixture.child }
+      get dinklage () {
+        return fixture.child
+      }
     },
-    get self () { return fixture }
+    get self () {
+      return fixture
+    }
   }
 
   const expected = s({
     name: 'Tywin Lannister',
     child: {
-      name: 'Tyrion Lannister', dinklage: '[Circular]'
+      name: 'Tyrion Lannister',
+      dinklage: '[Circular]'
     },
     self: '[Circular]'
   })
   const actual = fss(fixture)
+  assert.is(actual, expected)
+  assert.end()
+})
+
+test('depthLimit option - will replace deep objects', function (assert) {
+  const fixture = {
+    name: 'Tywin Lannister',
+    child: {
+      name: 'Tyrion Lannister'
+    },
+    get self () {
+      return fixture
+    }
+  }
+
+  const expected = s({
+    name: 'Tywin Lannister',
+    child: '[...]',
+    self: '[Circular]'
+  })
+  const actual = fss(fixture, undefined, undefined, {
+    depthLimit: 1,
+    edgesLimit: 1
+  })
+  assert.is(actual, expected)
+  assert.end()
+})
+
+test('edgesLimit option - will replace deep objects', function (assert) {
+  const fixture = {
+    object: {
+      1: { test: 'test' },
+      2: { test: 'test' },
+      3: { test: 'test' },
+      4: { test: 'test' }
+    },
+    array: [
+      { test: 'test' },
+      { test: 'test' },
+      { test: 'test' },
+      { test: 'test' }
+    ],
+    get self () {
+      return fixture
+    }
+  }
+
+  const expected = s({
+    object: {
+      1: { test: 'test' },
+      2: { test: 'test' },
+      3: { test: 'test' },
+      4: '[...]'
+    },
+    array: [{ test: 'test' }, { test: 'test' }, { test: 'test' }, '[...]'],
+    self: '[Circular]'
+  })
+  const actual = fss(fixture, undefined, undefined, {
+    depthLimit: 3,
+    edgesLimit: 3
+  })
   assert.is(actual, expected)
   assert.end()
 })


### PR DESCRIPTION
fix for #https://github.com/pinojs/pino/issues/990

- new feature to handle big deep objects - when limit reached object will be replaced with `[...]`
- new optional parameter options
- set default limits to 
   - depthLimit 10 - how deep parse input object
   - edgesLimit 20 - how deep parse object keys or array items
- test for optional parameter options
- updated changelog & readme 
- bump minor version to 2.1.0 