### PR TITLE
Use a higher depth and edge limit to avoid breaking people

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ var replacerStack = []
 
 function defaultOptions () {
   return {
-    depthLimit: 10,
-    edgesLimit: 20
+    depthLimit: Number.MAX_SAFE_INTEGER,
+    edgesLimit: Number.MAX_SAFE_INTEGER
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -35,9 +35,10 @@ function replacer(key, value) {
 }
 
 // those are also defaults limits when no options object is passed into safeStringify
+// configure it to lower the limit.
 const options = {
-  depthLimit: 10,
-  edgesLimit: 20,
+  depthLimit: Number.MAX_SAFE_INTEGER,
+  edgesLimit: Number.MAX_SAFE_INTEGER
 };
 
 const serialized = safeStringify(o, replacer, 2, options)


### PR DESCRIPTION
Fixes https://github.com/davidmarkclements/fast-safe-stringify/issues/57